### PR TITLE
Refactor eval

### DIFF
--- a/CompetitionEvaluation.py
+++ b/CompetitionEvaluation.py
@@ -56,47 +56,44 @@ def structure_data(observed: pd.DataFrame, predictions: pd.DataFrame, draw_colum
 
     # The samples must be named "member" and the outcome variable needs to be named the same in xs.crps_ensemble()
     
-    predictions = predictions.reset_index()
-    observed = observed.reset_index()
+    if predictions.index.names != [None]:
+        predictions = predictions.reset_index()
+    if observed.index.names != [None]:
+        observed = observed.reset_index()
 
-    if "index" in observed.columns:
-        observed = observed.drop(columns = ["index"])
-    if "index" in predictions.columns:
-        predictions = predictions.drop(columns = ["index"])
+    # assert "month_id" in observed.columns,  f"'month_id' column not found in observed data. Columns in data: {observed.columns}."
+    # assert "month_id" in predictions.columns,  f"'month_id' column not found in predictions data. Columns in data: {predictions.columns}."
 
-    assert "month_id" in observed.columns,  f"'month_id' column not found in observed data. Columns in data: {observed.columns}."
-    assert "month_id" in predictions.columns,  f"'month_id' column not found in predictions data. Columns in data: {predictions.columns}."
+    # assert observed.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in observed data."
+    # assert predictions.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in predictions data."
 
-    assert observed.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in observed data."
-    assert predictions.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in predictions data."
+    # assert draw_column_name in predictions.columns, f"{draw_column_name} not in predictions data. Columns in data: {predictions.columns}."
 
-    assert draw_column_name in predictions.columns, f"{draw_column_name} not in predictions data. Columns in data: {predictions.columns}."
-
-    assert data_column_name in predictions.columns, f"{data_column_name} not in predictions data. Columns in data: {predictions.columns}."
-    assert data_column_name in observed.columns, f"{data_column_name} not in observed data. Columns in data: {observed.columns}."
+    # assert data_column_name in predictions.columns, f"{data_column_name} not in predictions data. Columns in data: {predictions.columns}."
+    # assert data_column_name in observed.columns, f"{data_column_name} not in observed data. Columns in data: {observed.columns}."
 
 
-    assert len(observed.columns) == 3, f"Observed data should only be three variables: 'month_id', 'country_id' (or 'priogrid_gid'), and {data_column_name}. Columns in data: {observed.columns}."
-    assert len(predictions.columns) == 4, f"Predictions data should only be four variables: 'month_id', 'country_id' (or 'priogrid_gid'), {draw_column_name}, and {data_column_name}. Columns in data: {predictions.columns}."
+    # assert len(observed.columns) == 3, f"Observed data should only be three variables: 'month_id', 'country_id' (or 'priogrid_gid'), and {data_column_name}. Columns in data: {observed.columns}."
+    # assert len(predictions.columns) == 4, f"Predictions data should only be four variables: 'month_id', 'country_id' (or 'priogrid_gid'), {draw_column_name}, and {data_column_name}. Columns in data: {predictions.columns}."
 
-    onmonths = len(observed["month_id"].unique())
-    pnmonths = len(predictions["month_id"].unique())
+    # onmonths = len(observed["month_id"].unique())
+    # pnmonths = len(predictions["month_id"].unique())
 
-    if "priogrid_gid" in predictions.columns:
-        onunits = len(observed["priogrid_gid"].unique())
-        pnunits = len(predictions["priogrid_gid"].unique())
-    elif "country_id" in predictions.columns:
-        onunits = len(observed["country_id"].unique())
-        pnunits = len(predictions["country_id"].unique())
-    else:
-        TypeError("priogrid_gid or country_id must be an identifier")
+    # if "priogrid_gid" in predictions.columns:
+    #     onunits = len(observed["priogrid_gid"].unique())
+    #     pnunits = len(predictions["priogrid_gid"].unique())
+    # elif "country_id" in predictions.columns:
+    #     onunits = len(observed["country_id"].unique())
+    #     pnunits = len(predictions["country_id"].unique())
+    # else:
+    #     TypeError("priogrid_gid or country_id must be an identifier")
     
-    pnmembers = len(predictions[draw_column_name].unique())
+    # pnmembers = len(predictions[draw_column_name].unique())
 
-    assert len(predictions.index) == pnmonths*pnunits*pnmembers, f"Predictions data is not a balanced dataset with nobs: {len(predictions.index)} != months: {pnmonths} * units: {pnunits} * {draw_column_name}: {pnmembers}."
-    assert len(observed.index) == onmonths*onunits, f"Observed data is not a balanced dataset with nobs: {len(observed.index)} != months: {onmonths} * units: {onunits}."
-    assert pnmonths == onmonths, f'Months in prediction dataset ({pnmonths}) is not the same as in observed dataset ({onmonths}).'
-    assert pnunits == onunits, f'Units in prediction dataset ({pnunits}) is not the same as in observed dataset ({onunits}).'
+    # assert len(predictions.index) == pnmonths*pnunits*pnmembers, f"Predictions data is not a balanced dataset with nobs: {len(predictions.index)} != months: {pnmonths} * units: {pnunits} * {draw_column_name}: {pnmembers}."
+    # assert len(observed.index) == onmonths*onunits, f"Observed data is not a balanced dataset with nobs: {len(observed.index)} != months: {onmonths} * units: {onunits}."
+    # assert pnmonths == onmonths, f'Months in prediction dataset ({pnmonths}) is not the same as in observed dataset ({onmonths}).'
+    # assert pnunits == onunits, f'Units in prediction dataset ({pnunits}) is not the same as in observed dataset ({onunits}).'
 
     # To simplify internal affairs:
     predictions = predictions.rename(columns = {draw_column_name: "member", data_column_name: "outcome"})
@@ -139,6 +136,7 @@ def calculate_metrics(observed: xr.DataArray, predictions: xr.DataArray, metric:
         One of 'crps' (Ranked Probability Score), 'ign' (Ignorance Score), and 'mis' (Interval Score). 
     aggregate_over : str or list of str, optional
         Dimensions over which to compute mean after computing the evaluation metrics. E.g., 'month_id' calculates mean scores per unit, while ['month_id', 'country_id'] returns the global average.
+        Can also be "nothing". This will return the unaggregated scores.
     
     Additional arguments:
     
@@ -162,6 +160,10 @@ def calculate_metrics(observed: xr.DataArray, predictions: xr.DataArray, metric:
 
     interval_args = ['prediction_interval_level']
     interval_dict = {k: kwargs.pop(k) for k in dict(kwargs) if k in interval_args}
+
+    # Hack to circumvent the hardcoded res.mean() aggregation in xskillscore.crps_ensemble
+    if aggregate_over == "nothing":
+        predictions = predictions.expand_dims({"nothing": 1}) 
 
     # Calculate average crps for each step (so across the other dimensions)
     if metric == "crps":

--- a/CompetitionEvaluation.py
+++ b/CompetitionEvaluation.py
@@ -1,9 +1,6 @@
 import argparse
 import pandas as pd
 import pyarrow.parquet as pq
-from zipfile import ZipFile
-import numpy as np
-#from pathlib import Path
 
 # mamba install -c conda-forge xskillscore
 import xarray as xr
@@ -13,10 +10,13 @@ from IgnoranceScore import ensemble_ignorance_score_xskillscore
 from IntervalScore import mean_interval_score_xskillscore
 
 from typing import List, Union
+
 Dim = Union[List[str], str]
 
 
-def load_data(observed_path: str, forecasts_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+def load_data(
+    observed_path: str, forecasts_path: str
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Reads in parquet files of observed/actual/test and prediction/forecast data and returns pandas dataframes.
     Parameters
     ----------
@@ -24,19 +24,25 @@ def load_data(observed_path: str, forecasts_path: str) -> tuple[pd.DataFrame, pd
         Path to the parquet-file with observed/actual/test data.
     forecasts_path : str
         Path to the parquet-file with prediction/forecast data.
-    
+
     Returns
     -------
     observed, predictions : tuple (pandas.DataFrame, pandas.DataFrame)
     """
-        
+
     predictions = pq.read_table(forecasts_path)
     predictions = predictions.to_pandas()
     observed = pq.read_table(observed_path)
     observed = observed.to_pandas()
     return observed, predictions
 
-def structure_data(observed: pd.DataFrame, predictions: pd.DataFrame, draw_column_name: str = "draw", data_column_name: str = "outcome") -> tuple[xr.DataArray, xr.DataArray]:
+
+def structure_data(
+    observed: pd.DataFrame,
+    predictions: pd.DataFrame,
+    draw_column_name: str = "draw",
+    data_column_name: str = "outcome",
+) -> tuple[xr.DataArray, xr.DataArray]:
     """Structures data to the ViEWS 2023 Prediction Competition for use in calculate_metrics() function.
     Parameters
     ----------
@@ -48,70 +54,38 @@ def structure_data(observed: pd.DataFrame, predictions: pd.DataFrame, draw_colum
         The name of the column indicating forecast samples/draws in the predictions data.
     data_column_name : str
         The name of the column with outcomes. Must be the same in both the observed/test and predictions data.
-    
+
     Returns
     -------
     observed, predictions : tuple (xarray.DataArray, xarray.DataArray)
     """
 
     # The samples must be named "member" and the outcome variable needs to be named the same in xs.crps_ensemble()
-    
+
     if predictions.index.names != [None]:
         predictions = predictions.reset_index()
     if observed.index.names != [None]:
         observed = observed.reset_index()
 
-    # assert "month_id" in observed.columns,  f"'month_id' column not found in observed data. Columns in data: {observed.columns}."
-    # assert "month_id" in predictions.columns,  f"'month_id' column not found in predictions data. Columns in data: {predictions.columns}."
-
-    # assert observed.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in observed data."
-    # assert predictions.columns.isin(['country_id','priogrid_gid']).any(),  f"'country_id'/'priogrid_gid' column not found in predictions data."
-
-    # assert draw_column_name in predictions.columns, f"{draw_column_name} not in predictions data. Columns in data: {predictions.columns}."
-
-    # assert data_column_name in predictions.columns, f"{data_column_name} not in predictions data. Columns in data: {predictions.columns}."
-    # assert data_column_name in observed.columns, f"{data_column_name} not in observed data. Columns in data: {observed.columns}."
-
-
-    # assert len(observed.columns) == 3, f"Observed data should only be three variables: 'month_id', 'country_id' (or 'priogrid_gid'), and {data_column_name}. Columns in data: {observed.columns}."
-    # assert len(predictions.columns) == 4, f"Predictions data should only be four variables: 'month_id', 'country_id' (or 'priogrid_gid'), {draw_column_name}, and {data_column_name}. Columns in data: {predictions.columns}."
-
-    # onmonths = len(observed["month_id"].unique())
-    # pnmonths = len(predictions["month_id"].unique())
-
-    # if "priogrid_gid" in predictions.columns:
-    #     onunits = len(observed["priogrid_gid"].unique())
-    #     pnunits = len(predictions["priogrid_gid"].unique())
-    # elif "country_id" in predictions.columns:
-    #     onunits = len(observed["country_id"].unique())
-    #     pnunits = len(predictions["country_id"].unique())
-    # else:
-    #     TypeError("priogrid_gid or country_id must be an identifier")
-    
-    # pnmembers = len(predictions[draw_column_name].unique())
-
-    # assert len(predictions.index) == pnmonths*pnunits*pnmembers, f"Predictions data is not a balanced dataset with nobs: {len(predictions.index)} != months: {pnmonths} * units: {pnunits} * {draw_column_name}: {pnmembers}."
-    # assert len(observed.index) == onmonths*onunits, f"Observed data is not a balanced dataset with nobs: {len(observed.index)} != months: {onmonths} * units: {onunits}."
-    # assert pnmonths == onmonths, f'Months in prediction dataset ({pnmonths}) is not the same as in observed dataset ({onmonths}).'
-    # assert pnunits == onunits, f'Units in prediction dataset ({pnunits}) is not the same as in observed dataset ({onunits}).'
-
     # To simplify internal affairs:
-    predictions = predictions.rename(columns = {draw_column_name: "member", data_column_name: "outcome"})
-    observed = observed.rename(columns = {data_column_name: "outcome"})
+    predictions = predictions.rename(
+        columns={draw_column_name: "member", data_column_name: "outcome"}
+    )
+    observed = observed.rename(columns={data_column_name: "outcome"})
 
     predictions["month_id"] = predictions["month_id"].astype(int)
     # Set up multi-index to easily convert to xarray
     if "priogrid_gid" in predictions.columns:
         predictions["priogrid_gid"] = predictions["priogrid_gid"].astype(int)
-        predictions = predictions.set_index(['month_id', 'priogrid_gid', 'member'])
-        observed = observed.set_index(['month_id', 'priogrid_gid'])
+        predictions = predictions.set_index(["month_id", "priogrid_gid", "member"])
+        observed = observed.set_index(["month_id", "priogrid_gid"])
     elif "country_id" in predictions.columns:
         predictions["country_id"] = predictions["country_id"].astype(int)
-        predictions = predictions.set_index(['month_id', 'country_id', 'member'])
-        observed = observed.set_index(['month_id', 'country_id'])
+        predictions = predictions.set_index(["month_id", "country_id", "member"])
+        observed = observed.set_index(["month_id", "country_id"])
     else:
         TypeError("priogrid_gid or country_id must be an identifier")
-    
+
     # Convert to xarray
     xpred = predictions.to_xarray()
     xobserved = observed.to_xarray()
@@ -120,11 +94,20 @@ def structure_data(observed: pd.DataFrame, predictions: pd.DataFrame, draw_colum
     pdim = dict(xpred.dims)
     if "member" in pdim:
         del pdim["member"]
-    assert odim == pdim, f"observed and predictions must have matching shapes or matching shapes except the '{draw_column_name}' dimension"
+    assert (
+        odim == pdim
+    ), f"observed and predictions must have matching shapes or matching shapes except the '{draw_column_name}' dimension"
 
     return xobserved, xpred
 
-def calculate_metrics(observed: xr.DataArray, predictions: xr.DataArray, metric: str, aggregate_over: Dim, **kwargs) -> pd.DataFrame:
+
+def calculate_metrics(
+    observed: xr.DataArray,
+    predictions: xr.DataArray,
+    metric: str,
+    aggregate_over: Dim,
+    **kwargs,
+) -> pd.DataFrame:
     """Calculates evaluation metrics for the ViEWS 2023 Prediction Competition
     Parameters
     ----------
@@ -133,13 +116,13 @@ def calculate_metrics(observed: xr.DataArray, predictions: xr.DataArray, metric:
     forecasts : xarray.DataArray
         Forecasts with required member dimension ``member_dim``. Use structure_data to cast pandas data to this form.
     metric : str
-        One of 'crps' (Ranked Probability Score), 'ign' (Ignorance Score), and 'mis' (Interval Score). 
+        One of 'crps' (Ranked Probability Score), 'ign' (Ignorance Score), and 'mis' (Interval Score).
     aggregate_over : str or list of str, optional
         Dimensions over which to compute mean after computing the evaluation metrics. E.g., 'month_id' calculates mean scores per unit, while ['month_id', 'country_id'] returns the global average.
         Can also be "nothing". This will return the unaggregated scores.
-    
+
     Additional arguments:
-    
+
     If metric is 'ign':
     bins : int or monotonic list of scalars. If int, it defines the number of equal-width bins in the range low_bin - high_bin.
     low_bin : lower range of bins if bins is an int.
@@ -153,33 +136,51 @@ def calculate_metrics(observed: xr.DataArray, predictions: xr.DataArray, metric:
     xarray.Dataset or xarray.DataArray
     """
 
-    assert metric in ['crps', 'ign', "mis"], f'Metric: "{metric}" must be "crps", "ign", or "mis".'
+    assert metric in [
+        "crps",
+        "ign",
+        "mis",
+    ], f'Metric: "{metric}" must be "crps", "ign", or "mis".'
 
-    ign_args = ['prob_type', 'ign_max', 'round_values', 'axis', 'bins', 'low_bin', 'high_bin']
+    ign_args = [
+        "prob_type",
+        "ign_max",
+        "round_values",
+        "axis",
+        "bins",
+        "low_bin",
+        "high_bin",
+    ]
     ign_dict = {k: kwargs.pop(k) for k in dict(kwargs) if k in ign_args}
 
-    interval_args = ['prediction_interval_level']
+    interval_args = ["prediction_interval_level"]
     interval_dict = {k: kwargs.pop(k) for k in dict(kwargs) if k in interval_args}
 
     # Hack to circumvent the hardcoded res.mean() aggregation in xskillscore.crps_ensemble
     if aggregate_over == "nothing":
-        predictions = predictions.expand_dims({"nothing": 1}) 
+        predictions = predictions.expand_dims({"nothing": 1})
 
     # Calculate average crps for each step (so across the other dimensions)
     if metric == "crps":
         ensemble = xs.crps_ensemble(observed, predictions, dim=aggregate_over)
     elif metric == "ign":
-        ensemble = ensemble_ignorance_score_xskillscore(observed, predictions, dim=aggregate_over, **ign_dict)
+        ensemble = ensemble_ignorance_score_xskillscore(
+            observed, predictions, dim=aggregate_over, **ign_dict
+        )
     elif metric == "mis":
-        ensemble = mean_interval_score_xskillscore(observed, predictions, dim=aggregate_over, **interval_dict)
+        ensemble = mean_interval_score_xskillscore(
+            observed, predictions, dim=aggregate_over, **interval_dict
+        )
     else:
         TypeError(f'Metric: "{metric}" must be "crps", "ign", or "mis".')
 
-    if not ensemble.dims: # dicts return False if empty, dims is empty if only one value.
-        metrics = pd.DataFrame(ensemble.to_array().to_numpy(), columns = ["outcome"])
+    if (
+        not ensemble.dims
+    ):  # dicts return False if empty, dims is empty if only one value.
+        metrics = pd.DataFrame(ensemble.to_array().to_numpy(), columns=["outcome"])
     else:
         metrics = ensemble.to_dataframe()
-    metrics = metrics.rename(columns = {"outcome": metric})
+    metrics = metrics.rename(columns={"outcome": metric})
     return metrics
 
 
@@ -189,29 +190,102 @@ def write_metrics_to_file(metrics: pd.DataFrame, filepath: str) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="This calculates metrics for the ViEWS 2023 Forecast Competition",
-                                     epilog = "Example usage: python CompetitionEvaluation.py -o ./data/bm_cm_historical_values_2018.parquet -p ./data/bm_cm_ensemble_2018.parquet -m crps -ag month_id country_id")
-    parser.add_argument('-o', metavar='observed', type=str, help='path to csv-file where the observed outcomes are recorded')
-    parser.add_argument('-p', metavar='predictions', type=str, help='path to parquet file where the predictions are recorded in long format')
-    parser.add_argument('-m', metavar='metric', type=str, help='metric to compute: "crps" or "ign"')
-    parser.add_argument('-ag', metavar='aggregate_over', nargs = "+", type=str, help='Dimensions to aggregate over. Can be a list of several separated with whitespace. E.g., "-ag month_id country_id"', default = None)
-    parser.add_argument('-f', metavar='file', type=str, help='(Optional) path to csv-file where you want metrics to be stored')
-    parser.add_argument('-sc', metavar='sample-column-name', type=str, help='(Optional) name of column for the unique samples', default = "draw")
-    parser.add_argument('-dc', metavar='data-column-name', type=str, help='(Optional) name of column with data, must be same in both observed and predictions data', default = "outcome")
-    #parser.add_argument('-ipt', metavar = 'probability-type', type = int, help='One of 0-5, implements how probabilities are calculated. 3 is exact (elem_count / total).', default = 3)
-    #parser.add_argument('-imx', metavar = 'max-ign', type = float, help='Set a max ignorance score. None also allowed.', default = None)
-    parser.add_argument('-ib', metavar = 'ign-bins', nargs = "+", type = float, help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.', default = None)
-    parser.add_argument('-ibl', metavar = 'max-ign', type = int, help='Set a min bin value when binning is an integer.', default = 0)
-    parser.add_argument('-ibh', metavar = 'max-ign', type = int, help='Set a max bin value when binning is an integer.', default = 1000)
-    parser.add_argument('-pil', metavar = 'prediction-interval-level', type = float, help='Set prediction interval level for the interval score', default = 0.95)
-    
+    parser = argparse.ArgumentParser(
+        description="This calculates metrics for the ViEWS 2023 Forecast Competition",
+        epilog="Example usage: python CompetitionEvaluation.py -o ./data/bm_cm_historical_values_2018.parquet -p ./data/bm_cm_ensemble_2018.parquet -m crps -ag month_id country_id",
+    )
+    parser.add_argument(
+        "-o",
+        metavar="observed",
+        type=str,
+        help="path to csv-file where the observed outcomes are recorded",
+    )
+    parser.add_argument(
+        "-p",
+        metavar="predictions",
+        type=str,
+        help="path to parquet file where the predictions are recorded in long format",
+    )
+    parser.add_argument(
+        "-m", metavar="metric", type=str, help='metric to compute: "crps" or "ign"'
+    )
+    parser.add_argument(
+        "-ag",
+        metavar="aggregate_over",
+        nargs="+",
+        type=str,
+        help='Dimensions to aggregate over. Can be a list of several separated with whitespace. E.g., "-ag month_id country_id"',
+        default=None,
+    )
+    parser.add_argument(
+        "-f",
+        metavar="file",
+        type=str,
+        help="(Optional) path to csv-file where you want metrics to be stored",
+    )
+    parser.add_argument(
+        "-sc",
+        metavar="sample-column-name",
+        type=str,
+        help="(Optional) name of column for the unique samples",
+        default="draw",
+    )
+    parser.add_argument(
+        "-dc",
+        metavar="data-column-name",
+        type=str,
+        help="(Optional) name of column with data, must be same in both observed and predictions data",
+        default="outcome",
+    )
+    # parser.add_argument('-ipt', metavar = 'probability-type', type = int, help='One of 0-5, implements how probabilities are calculated. 3 is exact (elem_count / total).', default = 3)
+    # parser.add_argument('-imx', metavar = 'max-ign', type = float, help='Set a max ignorance score. None also allowed.', default = None)
+    parser.add_argument(
+        "-ib",
+        metavar="ign-bins",
+        nargs="+",
+        type=float,
+        help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.',
+        default=None,
+    )
+    parser.add_argument(
+        "-ibl",
+        metavar="max-ign",
+        type=int,
+        help="Set a min bin value when binning is an integer.",
+        default=0,
+    )
+    parser.add_argument(
+        "-ibh",
+        metavar="max-ign",
+        type=int,
+        help="Set a max bin value when binning is an integer.",
+        default=1000,
+    )
+    parser.add_argument(
+        "-pil",
+        metavar="prediction-interval-level",
+        type=float,
+        help="Set prediction interval level for the interval score",
+        default=0.95,
+    )
 
     args = parser.parse_args()
 
     observed, predictions = load_data(args.o, args.p)
-    observed, predictions = structure_data(observed, predictions, draw_column_name=args.sc, data_column_name = args.dc)
-    metrics = calculate_metrics(observed, predictions, metric = args.m, aggregate_over=args.ag, bins = args.ib, low_bin = args.ibl, high_bin = args.ibh, prediction_interval_level = args.pil)
-    if(args.f != None):
+    observed, predictions = structure_data(
+        observed, predictions, draw_column_name=args.sc, data_column_name=args.dc
+    )
+    metrics = calculate_metrics(
+        observed,
+        predictions,
+        metric=args.m,
+        aggregate_over=args.ag,
+        bins=args.ib,
+        low_bin=args.ibl,
+        high_bin=args.ibh,
+        prediction_interval_level=args.pil,
+    )
+    if args.f != None:
         write_metrics_to_file(metrics, args.f)
     else:
         print(metrics)

--- a/collect_performance.py
+++ b/collect_performance.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import argparse
 
-from utilities import list_submissions, get_predictions, views_month_id_to_year, views_month_id_to_month, TargetType, get_submission_details
+from utilities import list_submissions, get_target_data, views_month_id_to_year, views_month_id_to_month, TargetType, get_submission_details
 
 
 def get_eval(submission: str|os.PathLike, target: TargetType, groupby: str|list[str] = None) -> pd.DataFrame:
@@ -36,7 +36,7 @@ def get_eval(submission: str|os.PathLike, target: TargetType, groupby: str|list[
     """
 
     submission = Path(submission)
-    df = get_predictions(submission / "eval", target = target)
+    df = get_target_data(submission / "eval", target = target)
 
     if target == "cm":
         unit = "country_id"

--- a/evaluate_submissions.py
+++ b/evaluate_submissions.py
@@ -88,7 +88,7 @@ def evaluate_all_submissions(submissions: str|os.PathLike,
                              windows: list[str], 
                              expected: int, 
                              bins: list[float],
-                             sample_column: str = "draw", 
+                             draw_column: str = "draw", 
                              data_column: str = "outcome") -> None:
     """Loops over all submissions in the submissions folder, match them with the correct test dataset, and estimates evaluation metrics. 
     Stores evaluation data as .parquet files in {submissions}/{submission_name}/eval/{target}/window={window}/.
@@ -107,7 +107,7 @@ def evaluate_all_submissions(submissions: str|os.PathLike,
         The expected numbers of samples. Due to how Ignorance Score is defined, all IGN metric comparisons must be across models with equal number of samples.
     bins : list[float]
         The binning scheme used in the Ignorance Score.
-    sample_column : str
+    draw_column : str
         The name of the sample column. We assume samples are drawn independently from the model. Default = "draw"
     data_column : str
         The name of the data column. Default = "outcome"
@@ -130,8 +130,8 @@ def evaluate_all_submissions(submissions: str|os.PathLike,
                                         actuals = observed_df, 
                                         target = target,
                                         expected_samples = expected,
-                                        draw_column_name=sample_column,
-                                        data_column_name=data_column,
+                                        draw_column=draw_column,
+                                        data_column=data_column,
                                         bins = bins,
                                         save_to = save_to)
         except Exception as e:
@@ -145,7 +145,7 @@ def main():
     parser.add_argument('-t', metavar='targets', nargs = "+", type=str, help='pgm or cm or both', default = ["pgm", "cm"])
     parser.add_argument('-w', metavar='windows', nargs = "+", type=str, help='windows to evaluate', default = ["Y2018", "Y2019", "Y2020", "Y2021"])
     parser.add_argument('-e', metavar='expected', type=int, help='expected samples', default = 1000)
-    parser.add_argument('-sc', metavar='sample_column', type=str, help='(Optional) name of column for the unique samples', default = "draw")
+    parser.add_argument('-sc', metavar='draw_column', type=str, help='(Optional) name of column for the unique samples', default = "draw")
     parser.add_argument('-dc', metavar='data_column', type=str, help='(Optional) name of column with data, must be same in both observed and predictions data', default = "outcome")
     parser.add_argument('-ib', metavar = 'bins', nargs = "+", type = float, help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.', default = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5])    
 
@@ -157,11 +157,11 @@ def main():
     expected = args.e
     targets = args.t
     windows = args.w
-    sample_column = args.sc
+    draw_column = args.sc
     data_column = args.dc
     bins = args.ib
 
-    evaluate_all_submissions(submissions, acutals, targets, windows, expected, sample_column, data_column, bins)
+    evaluate_all_submissions(submissions, acutals, targets, windows, expected, draw_column, data_column, bins)
 
 
 if __name__ == "__main__":

--- a/evaluate_submissions.py
+++ b/evaluate_submissions.py
@@ -1,8 +1,6 @@
 from pathlib import Path
-import yaml
-from CompetitionEvaluation import load_data, structure_data, calculate_metrics
+from CompetitionEvaluation import structure_data, calculate_metrics
 from utilities import list_submissions, get_target_data, TargetType
-from dataclasses import dataclass
 import os
 import xarray
 import numpy as np
@@ -13,18 +11,35 @@ import pandas as pd
 import pyarrow
 
 import logging
+
 logging.getLogger(__name__)
-logging.basicConfig(filename='evaluate_submission.log', encoding='utf-8', level=logging.INFO)
+logging.basicConfig(
+    filename="evaluate_submission.log", encoding="utf-8", level=logging.INFO
+)
 
-def evaluate_forecast(forecast: pd.DataFrame, 
-                      actuals: pd.DataFrame, 
-                      target: TargetType,
-                      expected_samples: int,
-                      save_to: str|os.PathLike,
-                      draw_column: str ="draw", 
-                      data_column: str = "outcome",
-                      bins: list[float] = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5]) -> None:
 
+def evaluate_forecast(
+    forecast: pd.DataFrame,
+    actuals: pd.DataFrame,
+    target: TargetType,
+    expected_samples: int,
+    save_to: str | os.PathLike,
+    draw_column: str = "draw",
+    data_column: str = "outcome",
+    bins: list[float] = [
+        0,
+        0.5,
+        2.5,
+        5.5,
+        10.5,
+        25.5,
+        50.5,
+        100.5,
+        250.5,
+        500.5,
+        1000.5,
+    ],
+) -> None:
     if target == "pgm":
         unit = "priogrid_gid"
     elif target == "cm":
@@ -33,64 +48,95 @@ def evaluate_forecast(forecast: pd.DataFrame,
         raise ValueError(f'Target {target} must be either "pgm" or "cm".')
 
     # Cast to xarray
-    observed, predictions = structure_data(actuals, forecast, draw_column_name=draw_column, data_column_name = data_column)
+    observed, predictions = structure_data(
+        actuals, forecast, draw_column_name=draw_column, data_column_name=data_column
+    )
 
     if bool((predictions["outcome"] > 10e9).any()):
-        logging.warning(f'Found predictions larger than earth population. These are censored at 10 billion.')
-        predictions["outcome"] = xarray.where(predictions["outcome"]>10e9, 10e9, predictions["outcome"])
-        
-    crps = calculate_metrics(observed, predictions, metric = "crps", aggregate_over="nothing")
-    mis = calculate_metrics(observed, predictions, metric = "mis", prediction_interval_level = 0.9, aggregate_over="nothing")
+        logging.warning(
+            f"Found predictions larger than earth population. These are censored at 10 billion."
+        )
+        predictions["outcome"] = xarray.where(
+            predictions["outcome"] > 10e9, 10e9, predictions["outcome"]
+        )
 
-    if predictions.dims['member'] != expected_samples:
-        logging.warning(f'Number of samples ({predictions.dims["member"]}) is not 1000. Using scipy.signal.resample to get {expected_samples} samples when calculating Ignorance Score.')
+    crps = calculate_metrics(
+        observed, predictions, metric="crps", aggregate_over="nothing"
+    )
+    mis = calculate_metrics(
+        observed,
+        predictions,
+        metric="mis",
+        prediction_interval_level=0.9,
+        aggregate_over="nothing",
+    )
+
+    if predictions.dims["member"] != expected_samples:
+        logging.warning(
+            f'Number of samples ({predictions.dims["member"]}) is not 1000. Using scipy.signal.resample to get {expected_samples} samples when calculating Ignorance Score.'
+        )
         np.random.seed(284975)
-        arr: npt.ArrayLike = resample(predictions.to_array(), expected_samples, axis = 3)
-        arr = np.where(arr<0, 0, arr) # For the time when resampling happens to go below zero.
+        arr: npt.ArrayLike = resample(predictions.to_array(), expected_samples, axis=3)
+        arr = np.where(
+            arr < 0, 0, arr
+        )  # For the time when resampling happens to go below zero.
 
-        new_container = predictions.sel(member = 1)
-        new_container = new_container.expand_dims({"member": range(0,expected_samples)}).to_array().transpose("variable", "month_id", unit, "member")
-        predictions: xarray.Dataset = xarray.DataArray(data = arr, coords = new_container.coords).to_dataset(dim="variable")
+        new_container = predictions.sel(member=1)
+        new_container = (
+            new_container.expand_dims({"member": range(0, expected_samples)})
+            .to_array()
+            .transpose("variable", "month_id", unit, "member")
+        )
+        predictions: xarray.Dataset = xarray.DataArray(
+            data=arr, coords=new_container.coords
+        ).to_dataset(dim="variable")
 
     if bool((predictions["outcome"] < 0).any()):
-        logging.warning(f'Found negative predictions. These are censored at 0 before calculating Ignorance Score.')
-        predictions["outcome"] = xarray.where(predictions["outcome"]<0, 0, predictions["outcome"])
+        logging.warning(
+            f"Found negative predictions. These are censored at 0 before calculating Ignorance Score."
+        )
+        predictions["outcome"] = xarray.where(
+            predictions["outcome"] < 0, 0, predictions["outcome"]
+        )
+
+    ign = calculate_metrics(
+        observed, predictions, metric="ign", bins=bins, aggregate_over="nothing"
+    )
+
+    # Save data in .parquet long-format (month_id, unit_id, metric, value)
+    dfs = {"crps": crps, "ign": ign, "mis": mis}
+
+    for metric in ["crps", "ign", "mis"]:
+        dfs[metric].rename(columns={metric: "value"}, inplace=True)
+        metric_dir = save_to / f"metric={metric}"
+        metric_dir.mkdir(exist_ok=True, parents=True)
+        dfs[metric].to_parquet(metric_dir / f"{metric}.parquet")
 
 
-    ign = calculate_metrics(observed, predictions, metric = "ign", bins = bins, aggregate_over="nothing")
-    
-    # Long-format out
-    crps.rename(columns={"crps": "value"}, inplace=True)
-    ign.rename(columns={"ign": "value"}, inplace=True)
-    mis.rename(columns={"mis": "value"}, inplace=True)
-    
-    (save_to / "metric=crps").mkdir(exist_ok=True, parents = True)
-    (save_to / "metric=ign").mkdir(exist_ok=True, parents = True)
-    (save_to / "metric=mis").mkdir(exist_ok=True, parents = True)
-    crps.to_parquet(save_to / "metric=crps" / "crps.parquet")
-    ign.to_parquet(save_to / "metric=ign" / "ign.parquet")
-    mis.to_parquet(save_to / "metric=mis" / "mis.parquet")
-
-def match_forecast_with_actuals(submission, actuals_folder, target: TargetType, window: str):
-
+def match_forecast_with_actuals(
+    submission, actuals_folder, target: TargetType, window: str
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     filter = pyarrow.compute.field("window") == window
-    actuals = get_target_data(actuals_folder, target = target, filters = filter)
-    predictions = get_target_data(submission, target = target, filters = filter)
+    actuals = get_target_data(actuals_folder, target=target, filters=filter)
+    predictions = get_target_data(submission, target=target, filters=filter)
 
-    predictions.drop(columns=["window"], inplace = True)
-    actuals.drop(columns=["window"], inplace = True)
+    predictions.drop(columns=["window"], inplace=True)
+    actuals.drop(columns=["window"], inplace=True)
 
     return actuals, predictions
 
-def evaluate_submission(submission: str|os.PathLike, 
-                        acutals: str|os.PathLike, 
-                        targets: list[TargetType], 
-                        windows: list[str], 
-                        expected: int, 
-                        bins: list[float],
-                        draw_column: str = "draw", 
-                        data_column: str = "outcome") -> None:
-    """Loops over all targets and windows in a submission folder, match them with the correct test dataset, and estimates evaluation metrics. 
+
+def evaluate_submission(
+    submission: str | os.PathLike,
+    acutals: str | os.PathLike,
+    targets: list[TargetType],
+    windows: list[str],
+    expected: int,
+    bins: list[float],
+    draw_column: str = "draw",
+    data_column: str = "outcome",
+) -> None:
+    """Loops over all targets and windows in a submission folder, match them with the correct test dataset, and estimates evaluation metrics.
     Stores evaluation data as .parquet files in {submission}/eval/{target}/window={window}/.
 
     Parameters
@@ -112,30 +158,39 @@ def evaluate_submission(submission: str|os.PathLike,
     data_column : str
         The name of the data column. Default = "outcome"
     """
-    
+
     for target in targets:
         for window in windows:
-            if any((submission / target).glob("**/*.parquet")): # test if there are prediction files in the target
-                observed_df, pred_df = match_forecast_with_actuals(submission, acutals, target, window)
-                save_to = submission / "eval" / f'{target}' / f'window={window}'
-                evaluate_forecast(forecast = pred_df, 
-                                actuals = observed_df, 
-                                target = target,
-                                expected_samples = expected,
-                                draw_column=draw_column,
-                                data_column=data_column,
-                                bins = bins,
-                                save_to = save_to)
+            if any(
+                (submission / target).glob("**/*.parquet")
+            ):  # test if there are prediction files in the target
+                observed_df, pred_df = match_forecast_with_actuals(
+                    submission, acutals, target, window
+                )
+                save_to = submission / "eval" / f"{target}" / f"window={window}"
+                evaluate_forecast(
+                    forecast=pred_df,
+                    actuals=observed_df,
+                    target=target,
+                    expected_samples=expected,
+                    draw_column=draw_column,
+                    data_column=data_column,
+                    bins=bins,
+                    save_to=save_to,
+                )
 
-def evaluate_all_submissions(submissions: str|os.PathLike, 
-                             acutals: str|os.PathLike, 
-                             targets: list[TargetType], 
-                             windows: list[str], 
-                             expected: int, 
-                             bins: list[float],
-                             draw_column: str = "draw", 
-                             data_column: str = "outcome") -> None:
-    """Loops over all submissions in the submissions folder, match them with the correct test dataset, and estimates evaluation metrics. 
+
+def evaluate_all_submissions(
+    submissions: str | os.PathLike,
+    acutals: str | os.PathLike,
+    targets: list[TargetType],
+    windows: list[str],
+    expected: int,
+    bins: list[float],
+    draw_column: str = "draw",
+    data_column: str = "outcome",
+) -> None:
+    """Loops over all submissions in the submissions folder, match them with the correct test dataset, and estimates evaluation metrics.
     Stores evaluation data as .parquet files in {submissions}/{submission_name}/eval/{target}/window={window}/.
 
     Parameters
@@ -157,32 +212,85 @@ def evaluate_all_submissions(submissions: str|os.PathLike,
     data_column : str
         The name of the data column. Default = "outcome"
     """
-    
+
     submissions = Path(submissions)
     submissions = list_submissions(submissions)
     acutals = Path(acutals)
 
     for submission in submissions:
         try:
-            logging.info(f'Evaluating {submission.name}')
-            evaluate_submission(submission, acutals, targets, windows, expected, bins, draw_column, data_column)
+            logging.info(f"Evaluating {submission.name}")
+            evaluate_submission(
+                submission,
+                acutals,
+                targets,
+                windows,
+                expected,
+                bins,
+                draw_column,
+                data_column,
+            )
         except Exception as e:
-            logging.error(f'{str(e)}')
+            logging.error(f"{str(e)}")
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Method for evaluation of submissions to the ViEWS Prediction Challenge",
-                                     epilog = "Example usage: python evaluate_submissions.py -s ./submissions -a ./actuals -e 100")
-    parser.add_argument('-s', metavar='submissions', type=str, help='path to folder with submissions complying with submission_template')
-    parser.add_argument('-a', metavar='actuals', type=str, help='path to folder with actuals')
-    parser.add_argument('-t', metavar='targets', nargs = "+", type=str, help='pgm or cm or both', default = ["pgm", "cm"])
-    parser.add_argument('-w', metavar='windows', nargs = "+", type=str, help='windows to evaluate', default = ["Y2018", "Y2019", "Y2020", "Y2021"])
-    parser.add_argument('-e', metavar='expected', type=int, help='expected samples', default = 1000)
-    parser.add_argument('-sc', metavar='draw_column', type=str, help='(Optional) name of column for the unique samples', default = "draw")
-    parser.add_argument('-dc', metavar='data_column', type=str, help='(Optional) name of column with data, must be same in both observed and predictions data', default = "outcome")
-    parser.add_argument('-ib', metavar = 'bins', nargs = "+", type = float, help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.', default = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5])    
+    parser = argparse.ArgumentParser(
+        description="Method for evaluation of submissions to the ViEWS Prediction Challenge",
+        epilog="Example usage: python evaluate_submissions.py -s ./submissions -a ./actuals -e 100",
+    )
+    parser.add_argument(
+        "-s",
+        metavar="submissions",
+        type=str,
+        help="path to folder with submissions complying with submission_template",
+    )
+    parser.add_argument(
+        "-a", metavar="actuals", type=str, help="path to folder with actuals"
+    )
+    parser.add_argument(
+        "-t",
+        metavar="targets",
+        nargs="+",
+        type=str,
+        help="pgm or cm or both",
+        default=["pgm", "cm"],
+    )
+    parser.add_argument(
+        "-w",
+        metavar="windows",
+        nargs="+",
+        type=str,
+        help="windows to evaluate",
+        default=["Y2018", "Y2019", "Y2020", "Y2021"],
+    )
+    parser.add_argument(
+        "-e", metavar="expected", type=int, help="expected samples", default=1000
+    )
+    parser.add_argument(
+        "-sc",
+        metavar="draw_column",
+        type=str,
+        help="(Optional) name of column for the unique samples",
+        default="draw",
+    )
+    parser.add_argument(
+        "-dc",
+        metavar="data_column",
+        type=str,
+        help="(Optional) name of column with data, must be same in both observed and predictions data",
+        default="outcome",
+    )
+    parser.add_argument(
+        "-ib",
+        metavar="bins",
+        nargs="+",
+        type=float,
+        help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.',
+        default=[0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5],
+    )
 
     args = parser.parse_args()
-
 
     submissions = Path(args.s)
     acutals = Path(args.a)
@@ -193,7 +301,9 @@ def main():
     data_column = args.dc
     bins = args.ib
 
-    evaluate_all_submissions(submissions, acutals, targets, windows, expected, draw_column, data_column, bins)
+    evaluate_all_submissions(
+        submissions, acutals, targets, windows, expected, draw_column, data_column, bins
+    )
 
 
 if __name__ == "__main__":

--- a/evaluate_submissions.py
+++ b/evaluate_submissions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import yaml
 from CompetitionEvaluation import load_data, structure_data, calculate_metrics
-from utilities import list_submissions, get_predictions, TargetType
+from utilities import list_submissions, get_target_data, TargetType
 from dataclasses import dataclass
 import os
 import xarray
@@ -74,8 +74,8 @@ def evaluate_forecast(forecast: pd.DataFrame,
 def match_forecast_with_actuals(submission, actuals_folder, target: TargetType, window: str):
 
     filter = pyarrow.compute.field("window") == window
-    actuals = get_predictions(actuals_folder, target = target, filters = filter)
-    predictions = get_predictions(submission, target = target, filters = filter)
+    actuals = get_target_data(actuals_folder, target = target, filters = filter)
+    predictions = get_target_data(submission, target = target, filters = filter)
 
     predictions.drop(columns=["window"], inplace = True)
     actuals.drop(columns=["window"], inplace = True)

--- a/evaluate_submissions.py
+++ b/evaluate_submissions.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import yaml
 from CompetitionEvaluation import load_data, structure_data, calculate_metrics
+from utilities import list_submissions, get_predictions, TargetType
 from dataclasses import dataclass
 import os
 import xarray
@@ -8,100 +9,38 @@ import numpy as np
 import numpy.typing as npt
 from scipy.signal import resample
 import argparse
+import pandas as pd
+import pyarrow
 
 import logging
 logging.getLogger(__name__)
 logging.basicConfig(filename='evaluate_submission.log', encoding='utf-8', level=logging.INFO)
 
-def evaluate_forecast(forecast_file: str | os.PathLike, expected_samples: int, actuals_folder: str|os.PathLike, submission_root: str|os.PathLike) -> None:
-
-    @dataclass(frozen=True)
-    class Actuals:
-        target: str
-        test_window: str
-        parquet_file: str
-
-    actuals = [Actuals("cm", "test_window_2018", "cm_actuals_2018.parquet"),
-    Actuals("cm", "test_window_2019", "cm_actuals_2019.parquet"),
-    Actuals("cm", "test_window_2020", "cm_actuals_2020.parquet"),
-    Actuals("cm", "test_window_2021", "cm_actuals_2021.parquet"),
-    Actuals("pgm", "test_window_2018", "pgm_actuals_2018.parquet"),
-    Actuals("pgm", "test_window_2019", "pgm_actuals_2019.parquet"),
-    Actuals("pgm", "test_window_2020", "pgm_actuals_2020.parquet"),
-    Actuals("pgm", "test_window_2021", "pgm_actuals_2021.parquet")]
-
-    _, name, target, window = forecast_file.relative_to(submission_root).parent.parts
-    actual = [actual for actual in actuals if actual.target == target and actual.test_window == window]
-
-    if len(actual) != 1:
-        raise ValueError("Only one hit allowed.")
-    actual = actual[0]
-    actual_file = actuals_folder/actual.target/actual.test_window/actual.parquet_file
+def evaluate_forecast(forecast: pd.DataFrame, 
+                      actuals: pd.DataFrame, 
+                      target: TargetType,
+                      expected_samples: int,
+                      save_to: str|os.PathLike,
+                      draw_column_name: str ="draw", 
+                      data_column_name: str = "outcome",
+                      bins: list[float] = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5]) -> None:
 
     if target == "pgm":
-        target_column = "priogrid_gid"
+        unit = "priogrid_gid"
     elif target == "cm":
-        target_column = "country_id"
+        unit = "country_id"
     else:
         raise ValueError(f'Target {target} must be either "pgm" or "cm".')
 
-    observed, predictions = load_data(observed_path = actual_file, forecasts_path=forecast_file)
-
-    if predictions.index.names != ['month_id', target_column, 'draw']:
-        if predictions.index.names == [None] and all([var in predictions.columns for var in ['month_id', target_column, 'draw']]):
-            # Index is not set, but index variables are in the file.
-            predictions[target_column] = predictions[target_column].astype(int)
-            predictions["month_id"] = predictions["month_id"].astype(int)
-            predictions.set_index(['month_id', target_column, 'draw'], inplace = True)
-        else: 
-            logging.warning(f'Predictions file {forecast_file} does not have correct index. Currently: {predictions.index.names}')
-            if len(predictions.index.names) == 3:
-                logging.warning(f'Attempts to rename index.')
-                predictions.index.names = ['month_id', target_column, 'draw']
-            else:
-                raise ValueError(f'Predictions file {forecast_file} does not contain correct index columns.')
-
-    if len(observed.columns) == 1 and "outcome" not in observed.columns:
-        logging.warning(f'Actuals file {actual_file} does not have the "outcome" folder.')
-        logging.warning(f'Renaming column.')
-        observed.columns = ["outcome"]
-
-    if len(predictions.columns) == 1 and "outcome" not in observed.columns:
-        logging.warning(f'Predictions file {forecast_file} does not have the "outcome" folder.')
-        logging.warning(f'Renaming column.')
-        predictions.columns = ["outcome"]
-
-    if len(predictions.columns) != 1:
-        raise ValueError("Predictions file can only have 1 column.")
-
-    if len(observed.columns) != 1:
-        raise ValueError("Actuals file can only have 1 column.")
-    
-    #units_in_predictions_not_in_observed = [c for c in predictions.index.unique(level=target_column) if c not in observed.index.unique(level=target_column)]
-    #units_in_observed_not_in_predictions = [c for c in observed.index.unique(level=target_column) if c not in predictions.index.unique(level=target_column)]
-
-    #times_in_observed_not_in_predictions = [c for c in observed.index.unique(level="month_id") if c not in predictions.index.unique(level="month_id")]
-    #times_in_predictions_not_in_observed = [c for c in predictions.index.unique(level="month_id") if c not in observed.index.unique(level="month_id")]
-
-    #assert len(units_in_predictions_not_in_observed) == 0, f'Lacking actuals for {target_column}: {units_in_predictions_not_in_observed}'
-    #assert len(units_in_observed_not_in_predictions) == 0, f'Lacking predictions for {target_column}: {units_in_observed_not_in_predictions}'
-    #assert len(times_in_observed_not_in_predictions) == 0, f'Lacking predictions for {target_column}: {times_in_observed_not_in_predictions}'
-    #assert len(times_in_predictions_not_in_observed) == 0, f'Lacking actuals for {target_column}: {times_in_predictions_not_in_observed}'
-
-    observed, predictions = structure_data(observed, predictions, draw_column_name="draw", data_column_name = "outcome")
-
-    predictions[target_column] in observed[target_column]
-    predictions["month_id"] in observed["month_id"]
+    # Cast to xarray
+    observed, predictions = structure_data(actuals, forecast, draw_column_name=draw_column_name, data_column_name = data_column_name)
 
     if bool((predictions["outcome"] > 10e9).any()):
         logging.warning(f'Found predictions larger than earth population. These are censored at 10 billion.')
         predictions["outcome"] = xarray.where(predictions["outcome"]>10e9, 10e9, predictions["outcome"])
         
-    crps_per_unit = calculate_metrics(observed, predictions, metric = "crps", aggregate_over="month_id")
-    mis_per_unit = calculate_metrics(observed, predictions, metric = "mis", prediction_interval_level = 0.9, aggregate_over="month_id")
-
-    crps_per_month = calculate_metrics(observed, predictions, metric = "crps", aggregate_over=target_column)
-    mis_per_month = calculate_metrics(observed, predictions, metric = "mis", prediction_interval_level = 0.9, aggregate_over=target_column)
+    crps = calculate_metrics(observed, predictions, metric = "crps", aggregate_over="nothing")
+    mis = calculate_metrics(observed, predictions, metric = "mis", prediction_interval_level = 0.9, aggregate_over="nothing")
 
     if predictions.dims['member'] != expected_samples:
         logging.warning(f'Number of samples ({predictions.dims["member"]}) is not 1000. Using scipy.signal.resample to get {expected_samples} samples when calculating Ignorance Score.')
@@ -110,7 +49,7 @@ def evaluate_forecast(forecast_file: str | os.PathLike, expected_samples: int, a
         arr = np.where(arr<0, 0, arr) # For the time when resampling happens to go below zero.
 
         new_container = predictions.sel(member = 1)
-        new_container = new_container.expand_dims({"member": range(0,expected_samples)}).to_array().transpose("variable", "month_id", target_column, "member")
+        new_container = new_container.expand_dims({"member": range(0,expected_samples)}).to_array().transpose("variable", "month_id", unit, "member")
         predictions: xarray.Dataset = xarray.DataArray(data = arr, coords = new_container.coords).to_dataset(dim="variable")
 
     if bool((predictions["outcome"] < 0).any()):
@@ -118,54 +57,75 @@ def evaluate_forecast(forecast_file: str | os.PathLike, expected_samples: int, a
         predictions["outcome"] = xarray.where(predictions["outcome"]<0, 0, predictions["outcome"])
 
 
-    ign_per_unit = calculate_metrics(observed, predictions, metric = "ign", bins = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5], aggregate_over="month_id")
-    ign_per_month = calculate_metrics(observed, predictions, metric = "ign", bins = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5], aggregate_over=target_column)
+    ign = calculate_metrics(observed, predictions, metric = "ign", bins = bins, aggregate_over="nothing")
     
-    eval_path = forecast_file.parent/"eval"
-    eval_path.mkdir(exist_ok=True)
-    crps_per_unit.to_parquet(eval_path/"crps_per_unit.parquet")
-    crps_per_month.to_parquet(eval_path/"crps_per_month.parquet")
-    ign_per_unit.to_parquet(eval_path/"ign_per_unit.parquet")
-    ign_per_month.to_parquet(eval_path/"ign_per_month.parquet")
-    mis_per_unit.to_parquet(eval_path/"mis_per_unit.parquet")
-    mis_per_month.to_parquet(eval_path/"mis_per_month.parquet")
+    # Long-format out
+    crps.rename(columns={"ign": "value"}, inplace=True)
+    ign.rename(columns={"ign": "value"}, inplace=True)
+    mis.rename(columns={"ign": "value"}, inplace=True)
+    
+    (save_to / "metric=crps").mkdir(exist_ok=True, parents = True)
+    (save_to / "metric=ign").mkdir(exist_ok=True, parents = True)
+    (save_to / "metric=mis").mkdir(exist_ok=True, parents = True)
+    crps.to_parquet(save_to / "metric=crps" / "crps.parquet")
+    ign.to_parquet(save_to / "metric=ign" / "ign.parquet")
+    mis.to_parquet(save_to / "metric=mis" / "mis.parquet")
+
+def match_forecast_with_actuals(submission, actuals_folder, target: TargetType, year):
+
+    filter = pyarrow.compute.field("year") == year
+    actuals = get_predictions(actuals_folder, target = target, filters = filter)
+    predictions = get_predictions(submission, target = target, filters = filter)
+
+    predictions.drop(columns=["year"], inplace = True)
+    actuals.drop(columns=["year"], inplace = True)
+
+    return actuals, predictions
 
 def main():
     parser = argparse.ArgumentParser(description="Method for evaluation of submissions to the ViEWS Prediction Challenge",
                                      epilog = "Example usage: python evaluate_submissions.py -s ./submissions -a ./actuals -e 100")
     parser.add_argument('-s', metavar='submissions', type=str, help='path to folder with submissions complying with submission_template')
     parser.add_argument('-a', metavar='actuals', type=str, help='path to folder with actuals')
+    parser.add_argument('-t', metavar='targets', nargs = "+", type=str, help='pgm or cm or both', default = ["pgm", "cm"])
+    parser.add_argument('-y', metavar='years', nargs = "+", type=int, help='yearly windows to evaluate', default = [2018, 2019, 2020, 2021])
     parser.add_argument('-e', metavar='expected', type=int, help='expected samples', default = 1000)
+    parser.add_argument('-sc', metavar='sample-column-name', type=str, help='(Optional) name of column for the unique samples', default = "draw")
+    parser.add_argument('-dc', metavar='data-column-name', type=str, help='(Optional) name of column with data, must be same in both observed and predictions data', default = "outcome")
+    parser.add_argument('-ib', metavar = 'ign-bins', nargs = "+", type = float, help='Set a binning scheme for the ignorance score. List or integer (nbins). E.g., "--ib 0 0.5 1 5 10 100 1000". None also allowed.', default = [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5])    
+
     args = parser.parse_args()
 
 
     submission_path = Path(args.s)
     actuals_folder = Path(args.a)
     expected_samples = args.e
+    targets = args.t
+    years = args.y
+    sample_column_name = args.sc
+    data_column_name = args.dc
+    bins = args.ib
 
-    submission_root = submission_path.parent
-
-    submissions = [submission for submission in submission_path.iterdir() if submission.is_dir() and not submission.stem == "__MACOSX"]
+    submissions = list_submissions(submission_path)
 
     for submission in submissions:
-
         try:
-            with open(submission/"submission_details.yml") as f:
-                submission_details = yaml.safe_load(f)
-        except:
-            logging.error(f'{submission/"submission_details.yml"} could not be loaded.')
-
-        prediction_files = list(submission.glob("**/*.parquet"))
-        prediction_files = [f for f in prediction_files if not f.stem.split("_")[0] == "eval"]
-        prediction_files = [f for f in prediction_files if not f.parent.parts[-1] == "eval"]
-        prediction_files = [f for f in prediction_files if "__MACOSX" not in f.parts]
-        
-        for f in prediction_files:
-            try:
-                logging.info(f'Evaluating {str(f)}')
-                evaluate_forecast(f, expected_samples, actuals_folder, submission_root)
-            except Exception as e:
-                logging.error(f'{str(e)}')
+            logging.info(f'Evaluating {submission.name}')
+            for target in targets:
+                for year in years:
+                    if any((submission / target).glob("**/*.parquet")): # test if there are prediction files in the target
+                        actuals, predictions = match_forecast_with_actuals(submission, actuals_folder, target, year)
+                        save_to = submission / "eval" / f'target={target}' / f'year={year}'
+                        evaluate_forecast(forecast = predictions, 
+                                        actuals = actuals, 
+                                        target = target,
+                                        expected_samples = expected_samples,
+                                        draw_column_name=sample_column_name,
+                                        data_column_name=data_column_name,
+                                        bins = bins,
+                                        save_to = save_to)
+        except Exception as e:
+            logging.error(f'{str(e)}')
 
 
 if __name__ == "__main__":

--- a/evaluate_submissions.py
+++ b/evaluate_submissions.py
@@ -60,9 +60,9 @@ def evaluate_forecast(forecast: pd.DataFrame,
     ign = calculate_metrics(observed, predictions, metric = "ign", bins = bins, aggregate_over="nothing")
     
     # Long-format out
-    crps.rename(columns={"ign": "value"}, inplace=True)
+    crps.rename(columns={"crps": "value"}, inplace=True)
     ign.rename(columns={"ign": "value"}, inplace=True)
-    mis.rename(columns={"ign": "value"}, inplace=True)
+    mis.rename(columns={"mis": "value"}, inplace=True)
     
     (save_to / "metric=crps").mkdir(exist_ok=True, parents = True)
     (save_to / "metric=ign").mkdir(exist_ok=True, parents = True)
@@ -115,7 +115,7 @@ def main():
                 for year in years:
                     if any((submission / target).glob("**/*.parquet")): # test if there are prediction files in the target
                         actuals, predictions = match_forecast_with_actuals(submission, actuals_folder, target, year)
-                        save_to = submission / "eval" / f'target={target}' / f'year={year}'
+                        save_to = submission / "eval" / f'{target}' / f'year={year}'
                         evaluate_forecast(forecast = predictions, 
                                         actuals = actuals, 
                                         target = target,

--- a/utilities.py
+++ b/utilities.py
@@ -10,23 +10,82 @@ import yaml
 
 TargetType = Literal["cm", "pgm"]
 
-def get_submission_details(submission):
+def get_submission_details(submission: str|os.PathLike) -> dict:
+    """Reads the submission_details.yml file in a submission and returns a dictionary with its items.
+
+    Parameters
+    ----------
+    submission : str | os.PathLike
+        Path to a folder only containing folders structured like a submission_template
+
+    Returns
+    -------
+    dict
+        A dictionary with the elements in the YAML file.
+    """
     with open(submission/"submission_details.yml") as f:
         submission_details = yaml.safe_load(f)
     return submission_details
 
 def date_to_views_month_id(date: datetime.date) -> int:
+    """Takes a date and converts it to a "month_id", which is a count of months starting at 1 on January 1980. Works on vectors/columns of dates.
+
+    Parameters
+    ----------
+    date : datetime.date
+
+    Returns
+    -------
+    int
+        The month_id of the given date.
+    """
     views_start_date = datetime.date(1980, 1, 1)
     r = relativedelta(date, views_start_date)
     return (r.years * 12) + r.months + 1
 
-def views_month_id_to_year(month_id):
+def views_month_id_to_year(month_id: int) -> int:
+    """Converts a month_id to the calendar year of the month_id. Works on vectors/columns of month_ids.
+
+    Parameters
+    ----------
+    month_id : int
+        A count of months starting (from 1) on January 1980.
+
+    Returns
+    -------
+    int
+        The calendar year of the month_id.
+    """
     return 1980 + (month_id - 1) // 12
 
-def views_month_id_to_month(month_id):
+def views_month_id_to_month(month_id: int) -> int:
+    """Converts a month_id to the calendar month of the month_id
+
+    Parameters
+    ----------
+    month_id : int
+        A count of months starting (from 1) on January 1980.
+
+    Returns
+    -------
+    int
+        The calendar month of the month_id.
+    """
     return ((month_id - 1) % 12)+1
 
 def views_month_id_to_date(month_id: int) -> datetime.date:
+    """Converts a month_id to a datetime.date format.
+
+    Parameters
+    ----------
+    month_id : int
+        A count of months starting (from 1) on January 1980.
+
+    Returns
+    -------
+    datetime.date
+        The date of the month_id, using first day of the month format.
+    """
     df = pd.DataFrame()
     df["year"] = views_month_id_to_year(month_id)
     df["month"] = views_month_id_to_month(month_id)
@@ -62,12 +121,23 @@ def migrate_submission_from_old(submission: str|os.PathLike) -> None:
     [d.rmdir() for d in submission.glob(f'**/pgm/*/eval/')]
 
 def list_submissions(submissions_folder: str|os.PathLike) -> list[os.PathLike]:
+    """Creates a list of paths to folders inside the submissions_folder.
+
+    Parameters
+    ----------
+    submissions_folder : str | os.PathLike
+        Path to a folder only containing folders structured like a submission_template
+
+    Returns
+    -------
+    list[os.PathLike]
+        List of paths to submissions.
+    """
     submissions_folder = Path(submissions_folder)
     return [submission for submission in submissions_folder.iterdir() if submission.is_dir() and not submission.stem == "__MACOSX"]
     
 def read_parquet(data_path: str|os.PathLike, filters = None) -> pd.DataFrame:
-    """
-    This function does not need to be used directly, it is mostly to document how to read folders with parquet files or single parquet files with a filter.
+    """This function does not need to be used directly, it is mostly to document how to read folders with parquet files or single parquet files with a filter.
     
     Notes
     -----
@@ -86,9 +156,8 @@ def read_parquet(data_path: str|os.PathLike, filters = None) -> pd.DataFrame:
     table = pq.ParquetDataset(data_path, filters = filters)
     return table.read().to_pandas()
 
-def get_predictions(submission: str|os.PathLike, target: TargetType, filters = None) -> pd.DataFrame:
-    """
-    Reads folders with a "pgm" or "cm" sub-folder containing Apache Hive structured parquet-files.
+def get_target_data(submission: str|os.PathLike, target: TargetType, filters = None) -> pd.DataFrame:
+    """Reads folders with a "pgm" or "cm" sub-folder containing Apache Hive structured parquet-files.
     
     Notes
     -----
@@ -98,11 +167,11 @@ def get_predictions(submission: str|os.PathLike, target: TargetType, filters = N
     --------
     >>> import pyarrow.compute as pac
     >>> import pyarrow.parquet as pq
-    >>> from utilities import list_submissions, get_predictions
+    >>> from utilities import list_submissions, get_target_data
     
     >>> filter = pac.field("year") >= 2017
     >>> subs = list_submissions(./submissions/")
-    >>> df = get_predictions(subs[0], target = "pgm", filters = filter)
+    >>> df = get_target_data(subs[0], target = "pgm", filters = filter)
 
     """
     submission = Path(submission)

--- a/utilities.py
+++ b/utilities.py
@@ -6,8 +6,14 @@ import os
 import itertools
 from typing import Literal
 import datetime
+import yaml
 
 TargetType = Literal["cm", "pgm"]
+
+def get_submission_details(submission):
+    with open(submission/"submission_details.yml") as f:
+        submission_details = yaml.safe_load(f)
+    return submission_details
 
 def date_to_views_month_id(date: datetime.date) -> int:
     views_start_date = datetime.date(1980, 1, 1)
@@ -28,6 +34,14 @@ def views_month_id_to_date(month_id: int) -> datetime.date:
     return pd.to_datetime(df, format = "%Y%M")
 
 def migrate_submission_from_old(submission: str|os.PathLike) -> None:
+    """Helper function to migrate old submission folder structure to new structure based on Apache Hive.
+
+    Parameters
+    ----------
+    submission : str | os.PathLike
+        Folder following the old submission_template setup
+    """
+
     submission = Path(submission)
     eval_data = itertools.chain(submission.glob(f'**/cm/*/eval/*.parquet'),
                                 submission.glob(f'**/pgm/*/eval/*.parquet'))

--- a/utilities.py
+++ b/utilities.py
@@ -1,8 +1,31 @@
 from pathlib import Path
 import pyarrow.dataset as pad
+import pyarrow.parquet as pq
+import pandas as pd
 import os
 import itertools
 from typing import Literal
+import datetime
+
+type TargetType = Literal["cm", "pgm"]
+
+def date_to_views_month_id(date: datetime.date) -> int:
+    views_start_date = datetime.date(1980, 1, 1)
+    r = relativedelta(date, views_start_date)
+    return (r.years * 12) + r.months + 1
+
+def views_month_id_to_year(month_id):
+    return 1980 + (month_id - 1) // 12
+
+def views_month_id_to_month(month_id):
+    return ((month_id - 1) % 12)+1
+
+def views_month_id_to_date(month_id: int) -> datetime.date:
+    df = pd.DataFrame()
+    df["year"] = views_month_id_to_year(month_id)
+    df["month"] = views_month_id_to_month(month_id)
+    df["day"] = 1
+    return pd.to_datetime(df, format = "%Y%M")
 
 def migrate_submission_from_old(submission: str|os.PathLike) -> None:
     submission = Path(submission)
@@ -15,7 +38,7 @@ def migrate_submission_from_old(submission: str|os.PathLike) -> None:
         f.rename(eval_folder_path / f.name)
     
     def folder_rename(d):
-        new_name = d.parent / f'window={d.name.split("_")[-1]}'
+        new_name = d.parent / f'year={d.name.split("_")[-1]}'
         d.rename(new_name)
 
     # Rename window folders in Apache Hive format
@@ -34,6 +57,27 @@ def list_submissions(submissions_folder: str|os.PathLike) -> list[os.PathLike]:
     submissions_folder = Path(submissions_folder)
     return [submission for submission in submissions_folder.iterdir() if submission.is_dir() and not submission.stem == "__MACOSX"]
 
-TargetType = Literal["cm", "pgm"]
+def read_features(feature_folder: str|os.PathLike, target: TargetType, filters) -> pd.DataFrame:
+    """
+    See https://arrow.apache.org/docs/python/compute.html#filtering-by-expressions for filter examples
+    
+    import pyarrow.compute as pac
+    filter = pac.field("year") >= 2017
+    """
+    feature_folder = Path(feature_folder)
+    assert (feature_folder / target).exists()
+    assert (feature_folder / "cm_features.parquet").exists()
+
+    if target == "pgm":
+        data_path = feature_folder / target
+    elif target == "cm":
+        data_path = feature_folder / "cm_features.parquet"
+    else:
+        ValueError(f'Target must be either "pgm" or "cm".')
+        
+    table = pq.ParquetDataset(data_path, filters = filters)
+    return table.read().to_pandas()
+
+
 def get_predictions(submission: str|os.PathLike, target: TargetType) -> pad.Dataset:
     pass

--- a/utilities.py
+++ b/utilities.py
@@ -8,6 +8,9 @@ from typing import Literal
 import datetime
 import yaml
 
+import logging
+logging.getLogger(__name__)
+
 TargetType = Literal["cm", "pgm"]
 
 def get_submission_details(submission: str|os.PathLike) -> dict:
@@ -156,6 +159,24 @@ def read_parquet(data_path: str|os.PathLike, filters = None) -> pd.DataFrame:
     table = pq.ParquetDataset(data_path, filters = filters)
     return table.read().to_pandas()
 
+def data_in_target(submission: str|os.PathLike, target: TargetType) -> bool:
+    """Test if there are any .parquet-files in the {submission}/{target} sub-folders.
+
+    Parameters
+    ----------
+    submission : str | os.PathLike
+        Path to a folder only containing folders structured like a submission_template
+    target : TargetType
+        A string, either "pgm" for PRIO-GRID-months, or "cm" for country-months.
+
+    Returns
+    -------
+    bool
+        True if there are any .parquet files in target sub-folders.
+    """
+    return any((submission / target).glob("**/*.parquet"))
+
+
 def get_target_data(submission: str|os.PathLike, target: TargetType, filters = None) -> pd.DataFrame:
     """Reads folders with a "pgm" or "cm" sub-folder containing Apache Hive structured parquet-files.
     
@@ -175,7 +196,7 @@ def get_target_data(submission: str|os.PathLike, target: TargetType, filters = N
 
     """
     submission = Path(submission)
-    return read_parquet(submission / target, filters = filters)
+    return read_parquet(submission / target, filters = filters)    
 
 def get_window_filters(window):
     pass

--- a/utilities.py
+++ b/utilities.py
@@ -45,23 +45,17 @@ def migrate_submission_from_old(submission: str|os.PathLike) -> None:
     submission = Path(submission)
     eval_data = itertools.chain(submission.glob(f'**/cm/*/eval/*.parquet'),
                                 submission.glob(f'**/pgm/*/eval/*.parquet'))
-    def file_rename(f):
-        target, window = f.parent.parts[-3:-1]
-        eval_folder_path = submission / "eval" / target / window
-        eval_folder_path.mkdir(parents=True, exist_ok=True)
-        f.rename(eval_folder_path / f.name)
-    
+        
     def folder_rename(d):
-        new_name = d.parent / f'year={d.name.split("_")[-1]}'
+        new_name = d.parent / f'window=Y{d.name.split("_")[-1]}'
         d.rename(new_name)
 
     # Rename window folders in Apache Hive format
     window_folders = itertools.chain(submission.glob(f'cm/test_window_*'), submission.glob(f'pgm/test_window_*'))
     [folder_rename(d) for d in window_folders]
-    # Move evaluation files into eval folder
-    [file_rename(f) for f in eval_data]        
-    # Move summary files into eval folder
-    [f.rename(submission / "eval" / f.name) for f in submission.glob(f'eval*.parquet')]
+    # Delete evaluation files (must be re-estimated)
+    [f.unlink() for f in eval_data]        
+    [f.unlink() for f in submission.glob(f'eval*.parquet')]
     
     # Cleanup old folders (only deletes if empty)
     [d.rmdir() for d in submission.glob(f'**/cm/*/eval/')]
@@ -70,7 +64,7 @@ def migrate_submission_from_old(submission: str|os.PathLike) -> None:
 def list_submissions(submissions_folder: str|os.PathLike) -> list[os.PathLike]:
     submissions_folder = Path(submissions_folder)
     return [submission for submission in submissions_folder.iterdir() if submission.is_dir() and not submission.stem == "__MACOSX"]
-
+    
 def read_parquet(data_path: str|os.PathLike, filters = None) -> pd.DataFrame:
     """
     This function does not need to be used directly, it is mostly to document how to read folders with parquet files or single parquet files with a filter.
@@ -113,3 +107,6 @@ def get_predictions(submission: str|os.PathLike, target: TargetType, filters = N
     """
     submission = Path(submission)
     return read_parquet(submission / target, filters = filters)
+
+def get_window_filters(window):
+    pass

--- a/utilities.py
+++ b/utilities.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import pyarrow.dataset as pad
+import os
+import itertools
+from typing import Literal
+
+def migrate_submission_from_old(submission: str|os.PathLike) -> None:
+    submission = Path(submission)
+    eval_data = itertools.chain(submission.glob(f'**/cm/*/eval/*.parquet'),
+                                submission.glob(f'**/pgm/*/eval/*.parquet'))
+    def file_rename(f):
+        target, window = f.parent.parts[-3:-1]
+        eval_folder_path = submission / "eval" / target / window
+        eval_folder_path.mkdir(parents=True, exist_ok=True)
+        f.rename(eval_folder_path / f.name)
+    
+    def folder_rename(d):
+        new_name = d.parent / f'window={d.name.split("_")[-1]}'
+        d.rename(new_name)
+
+    # Rename window folders in Apache Hive format
+    window_folders = itertools.chain(submission.glob(f'cm/test_window_*'), submission.glob(f'pgm/test_window_*'))
+    [folder_rename(d) for d in window_folders]
+    # Move evaluation files into eval folder
+    [file_rename(f) for f in eval_data]        
+    # Move summary files into eval folder
+    [f.rename(submission / "eval" / f.name) for f in submission.glob(f'eval*.parquet')]
+    
+    # Cleanup old folders (only deletes if empty)
+    [d.rmdir() for d in submission.glob(f'**/cm/*/eval/')]
+    [d.rmdir() for d in submission.glob(f'**/pgm/*/eval/')]
+
+def list_submissions(submissions_folder: str|os.PathLike) -> list[os.PathLike]:
+    submissions_folder = Path(submissions_folder)
+    return [submission for submission in submissions_folder.iterdir() if submission.is_dir() and not submission.stem == "__MACOSX"]
+
+TargetType = Literal["cm", "pgm"]
+def get_predictions(submission: str|os.PathLike, target: TargetType) -> pad.Dataset:
+    pass


### PR DESCRIPTION
A larger refactor of the whole project, including how we store features data, actuals (test) data, and submissions with predictions and evaluation data. The overarching idea is to use a [pyarrow.dataset.Dataset](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html) in the Apache Hive flavor. Particularly, all data is structured with a root_folder/{target}/{Apache Hive} where target can be "cm" or "pgm". The Apache Hive uses folder name conventions like "variable_name=variable_value", and we can target the root/{target} folder to read the whole dataset (i.e., without targetting any .parquet-file directly). The benefit of this is ready particularly for the pgm-level, as it becomes easy to read only subsets of the data to avoid running out of memory. Aggregation of data also becomes easier to handle. The refactor includes also a utility-module that include helper functions (e.g., getting calendar years and months from month_id).